### PR TITLE
feat: redesign navbar, footer and add quick add-to-portfolio from coi…

### DIFF
--- a/app/coin/[id]/coin-page.tsx
+++ b/app/coin/[id]/coin-page.tsx
@@ -17,6 +17,7 @@ import { AllTimeStats } from '@/src/components/coin/all-time-stats';
 import { PriceHighLow } from '@/src/components/coin/price-high-low';
 import { CoinPageSkeleton } from '@/src/components/skeletons/coin-page-skeleton';
 import { CoinNotes } from '@/src/components/coin/coin-notes';
+import { AddToPortfolioButton } from '@/src/components/coin/add-to-portfolio-button';
 import Image from 'next/image';
 
 interface CoinPageProps {
@@ -67,17 +68,23 @@ export default function CoinPage({ params }: CoinPageProps) {
 				<CoinPageSkeleton />
 			) : (
 				<>
-					<div className="flex flex-col md:flex-row justify-between items-start mb-6">
-						<div className="flex items-center gap-4 mb-4 md:mb-0">
-							{coin.image && <Image src={coin.image || '/placeholder.svg'} alt={coin.name} width={48} height={48} className="rounded-full" />}
+					{/* Coin header */}
+					<div className="flex flex-col sm:flex-row justify-between items-start gap-4 mb-6">
+						<div className="flex items-center gap-4">
+							{coin.image && (
+								<Image src={coin.image || '/placeholder.svg'} alt={coin.name} width={48} height={48} className="rounded-full" />
+							)}
 							<div>
-								<div className="flex items-center gap-3">
+								<div className="flex items-center gap-3 flex-wrap">
 									<h1 className="text-3xl font-bold first-letter:uppercase">{coin.name}</h1>
 									<Badge variant="outline" className="uppercase">
 										{coin.symbol}
 									</Badge>
 									<Button variant="ghost" size="icon" onClick={() => toggleFavorite(params.id)} className="h-8 w-8">
-										<Star className={`h-5 w-5 ${favorites.includes(params.id) ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground'}`} aria-pressed={favorites.includes(params.id)} />
+										<Star
+											className={`h-5 w-5 ${favorites.includes(params.id) ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground'}`}
+											aria-pressed={favorites.includes(params.id)}
+										/>
 									</Button>
 									<Button variant="ghost" size="icon" onClick={handleShare} className="h-8 w-8" title="Copy link">
 										{copied ? <Check className="h-4 w-4 text-emerald-500" /> : <Share2 className="h-4 w-4 text-muted-foreground" />}
@@ -88,6 +95,9 @@ export default function CoinPage({ params }: CoinPageProps) {
 								</div>
 							</div>
 						</div>
+
+						{/* Add to Portfolio CTA */}
+						<AddToPortfolioButton coinId={params.id} coinName={coin.name} />
 					</div>
 
 					<div className="flex flex-col lg:flex-row gap-6">
@@ -147,7 +157,9 @@ export default function CoinPage({ params }: CoinPageProps) {
 												<CardTitle>About {coin.name}</CardTitle>
 											</CardHeader>
 											<CardContent>
-												<p className="text-muted-foreground">Information about {coin.name} would appear here. This could include a description, use cases, technology, team information, and more.</p>
+												<p className="text-muted-foreground">
+													Information about {coin.name} would appear here. This could include a description, use cases, technology, team information, and more.
+												</p>
 											</CardContent>
 										</Card>
 										<Card>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,10 +45,10 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
 						<Toaster />
 						<CommandPalette />
 						<PriceTicker />
-						<div className="container mx-auto mt-4 flex-grow">
-							<Navbar />
+						<Navbar />
+						<main className="container mx-auto flex-grow px-4 py-6">
 							{children}
-						</div>
+						</main>
 						<Footer />
 					</SessionProvider>
 				</Providers>

--- a/src/actions/portfolio/portfolio.ts
+++ b/src/actions/portfolio/portfolio.ts
@@ -47,3 +47,10 @@ export async function deletePortfolio(portfolioId: string): Promise<Portfolio> {
 export async function getUserPortfolios(userId: string): Promise<Portfolio[]> {
 	return await getUserPortfoliosWithUserId(userId);
 }
+
+export async function getMyPortfolios(): Promise<Portfolio[]> {
+	const { auth } = await import('@/auth');
+	const session = await auth();
+	if (!session?.user?.id) return [];
+	return await getUserPortfoliosWithUserId(session.user.id);
+}

--- a/src/components/coin/add-to-portfolio-button.tsx
+++ b/src/components/coin/add-to-portfolio-button.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { PlusCircle, Check, Loader2 } from 'lucide-react';
+import { Button } from '@/src/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/src/components/ui/popover';
+import { getMyPortfolios } from '@/src/actions/portfolio/portfolio';
+import { addCoinToPortfolio } from '@/src/actions/portfolio/portfolioCoin';
+import { useToast } from '@/src/hooks/use-toast';
+import { Portfolio } from '@/src/schemas/';
+import Link from 'next/link';
+
+interface AddToPortfolioButtonProps {
+	coinId: string;
+	coinName: string;
+}
+
+export function AddToPortfolioButton({ coinId, coinName }: AddToPortfolioButtonProps) {
+	const [open, setOpen] = useState(false);
+	const [selected, setSelected] = useState<Portfolio | null>(null);
+	const [adding, setAdding] = useState(false);
+	const { toast } = useToast();
+
+	const { data: portfolios = [], isLoading } = useQuery({
+		queryKey: ['my-portfolios'],
+		queryFn: () => getMyPortfolios(),
+		enabled: open,
+		staleTime: 60_000
+	});
+
+	async function handleAdd() {
+		if (!selected) return;
+		setAdding(true);
+		try {
+			await addCoinToPortfolio(selected.id, coinId);
+			toast({
+				title: 'Added to portfolio',
+				description: `${coinName} was added to "${selected.name}"`
+			});
+			setOpen(false);
+			setSelected(null);
+		} catch {
+			toast({ title: 'Error', description: 'Failed to add coin to portfolio', variant: 'destructive' });
+		} finally {
+			setAdding(false);
+		}
+	}
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button variant="outline" size="sm" className="gap-2 h-8">
+					<PlusCircle size={14} />
+					Add to Portfolio
+				</Button>
+			</PopoverTrigger>
+
+			<PopoverContent className="w-60 p-3" align="end">
+				<p className="text-sm font-semibold mb-2">Select portfolio</p>
+
+				{isLoading ? (
+					<div className="flex justify-center py-4">
+						<Loader2 size={16} className="animate-spin text-muted-foreground" />
+					</div>
+				) : portfolios.length === 0 ? (
+					<p className="text-xs text-muted-foreground py-2">
+						No portfolios yet.{' '}
+						<Link href="/dashboard" className="text-primary hover:underline" onClick={() => setOpen(false)}>
+							Create one
+						</Link>
+					</p>
+				) : (
+					<div className="space-y-1 mb-3 max-h-48 overflow-y-auto">
+						{portfolios.map((p) => (
+							<button
+								key={p.id}
+								onClick={() => setSelected(p)}
+								className={`w-full text-left px-3 py-2 rounded-md text-sm flex items-center justify-between hover:bg-muted transition-colors ${
+									selected?.id === p.id ? 'bg-muted font-medium' : ''
+								}`}
+							>
+								<span className="truncate">{p.name}</span>
+								{selected?.id === p.id && <Check size={13} className="text-primary shrink-0 ml-1" />}
+							</button>
+						))}
+					</div>
+				)}
+
+				{portfolios.length > 0 && (
+					<Button size="sm" className="w-full mt-1" disabled={!selected || adding} onClick={handleAdd}>
+						{adding ? (
+							<>
+								<Loader2 size={13} className="animate-spin mr-1.5" />
+								Adding…
+							</>
+						) : (
+							'Confirm'
+						)}
+					</Button>
+				)}
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/src/components/command-palette-button.tsx
+++ b/src/components/command-palette-button.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Button } from '@/src/components/ui/button';
+import { Search } from 'lucide-react';
+
+export function CommandPaletteButton() {
+	function trigger() {
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }));
+	}
+
+	return (
+		<Button
+			variant="outline"
+			size="sm"
+			onClick={trigger}
+			className="h-8 gap-2 text-muted-foreground text-xs hidden sm:flex px-3"
+		>
+			<Search size={13} />
+			<span>Search</span>
+			<kbd className="ml-1 text-[10px] bg-muted border border-border px-1.5 py-0.5 rounded font-mono">⌘K</kbd>
+		</Button>
+	);
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,14 +1,44 @@
 import Link from 'next/link';
-import Image from 'next/image';
-import { Github } from 'lucide-react';
+import { TrendingUp, Github } from 'lucide-react';
 
 export default function Footer() {
 	return (
-		<footer className="relative p-6 mt-4 bg-foreground">
-			<div className="flex items-center gap-4 justify-center">
-				<Link href="https://github.com/pierrebre/financeflow" className="text-background" target="_blank" prefetch={true} aria-label="Github link for project">
-					<Github className="text-background" name="Github" />
-				</Link>
+		<footer className="border-t bg-background mt-8">
+			<div className="container mx-auto px-4 py-8">
+				<div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+					{/* Brand */}
+					<div className="flex items-center gap-2 font-semibold text-sm">
+						<div className="flex items-center justify-center w-6 h-6 rounded-md bg-primary">
+							<TrendingUp size={13} className="text-primary-foreground" />
+						</div>
+						FinanceFlow
+					</div>
+
+					{/* Links */}
+					<nav className="flex items-center gap-6 text-xs text-muted-foreground">
+						<Link href="/" className="hover:text-foreground transition-colors">Markets</Link>
+						<Link href="/dashboard" className="hover:text-foreground transition-colors">Dashboard</Link>
+						<Link href="/watchlist" className="hover:text-foreground transition-colors">Watchlist</Link>
+						<Link href="/blog" className="hover:text-foreground transition-colors">Blog</Link>
+					</nav>
+
+					{/* Social */}
+					<div className="flex items-center gap-3">
+						<Link
+							href="https://github.com/pierrebre/financeflow"
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="GitHub repository"
+							className="text-muted-foreground hover:text-foreground transition-colors"
+						>
+							<Github size={18} />
+						</Link>
+					</div>
+				</div>
+
+				<p className="text-center text-xs text-muted-foreground mt-6">
+					© {new Date().getFullYear()} FinanceFlow. Data powered by CoinGecko.
+				</p>
 			</div>
 		</footer>
 	);

--- a/src/components/mobile-menu.tsx
+++ b/src/components/mobile-menu.tsx
@@ -2,53 +2,54 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/src/components/ui/dropdown-menu';
+import { usePathname } from 'next/navigation';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/src/components/ui/dropdown-menu';
+import { BarChart2, LayoutDashboard, Star, BookOpen } from 'lucide-react';
 
-function AnimatedHamburger({ className = '', isOpen }: { className?: string; isOpen: boolean }) {
+function AnimatedHamburger({ isOpen }: { isOpen: boolean }) {
 	return (
-		<div className={`w-6 h-6 relative ${className}`}>
+		<div className="w-6 h-6 relative hover:text-primary transition-colors">
 			<div className="absolute w-6 h-6 flex flex-col justify-center items-center">
-				<span
-					className={`
-            absolute h-0.5 w-5 bg-current transform transition-all duration-300 ease-in-out
-            ${isOpen ? 'rotate-45 translate-y-0' : '-translate-y-2'}
-          `}
-				/>
-				<span
-					className={`
-            absolute h-0.5 w-5 bg-current transform transition-all duration-300 ease-in-out
-            ${isOpen ? 'opacity-0 translate-x-3' : 'opacity-100 translate-x-0'}
-          `}
-				/>
-				<span
-					className={`
-            absolute h-0.5 w-5 bg-current transform transition-all duration-300 ease-in-out
-            ${isOpen ? '-rotate-45 translate-y-0' : 'translate-y-2'}
-          `}
-				/>
+				<span className={`absolute h-0.5 w-5 bg-current transform transition-all duration-300 ease-in-out ${isOpen ? 'rotate-45 translate-y-0' : '-translate-y-2'}`} />
+				<span className={`absolute h-0.5 w-5 bg-current transform transition-all duration-300 ease-in-out ${isOpen ? 'opacity-0 translate-x-3' : 'opacity-100 translate-x-0'}`} />
+				<span className={`absolute h-0.5 w-5 bg-current transform transition-all duration-300 ease-in-out ${isOpen ? '-rotate-45 translate-y-0' : 'translate-y-2'}`} />
 			</div>
 		</div>
 	);
 }
 
+const links = [
+	{ href: '/', label: 'Markets', icon: BarChart2 },
+	{ href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+	{ href: '/watchlist', label: 'Watchlist', icon: Star },
+	{ href: '/blog', label: 'Blog', icon: BookOpen }
+];
+
 export default function MobileMenu() {
 	const [isOpen, setIsOpen] = useState(false);
+	const pathname = usePathname();
 
 	return (
 		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-			<DropdownMenuTrigger className="lg:hidden ml-4 focus:outline-none" aria-label="Toggle menu">
-				<AnimatedHamburger className="hover:text-primary transition-colors" isOpen={isOpen} />
+			<DropdownMenuTrigger className="lg:hidden ml-2 focus:outline-none" aria-label="Toggle menu">
+				<AnimatedHamburger isOpen={isOpen} />
 			</DropdownMenuTrigger>
-			<DropdownMenuContent className="w-48">
-				<DropdownMenuItem className="cursor-pointer">
-					<Link href="/watchlist" className="w-full">
-						Watchlist
-					</Link>
-				</DropdownMenuItem>
-				<DropdownMenuItem className="cursor-pointer">
-					<Link href="/blog" className="w-full">
-						Blog
-					</Link>
+			<DropdownMenuContent align="end" className="w-52">
+				{links.map(({ href, label, icon: Icon }) => (
+					<DropdownMenuItem key={href} asChild className="cursor-pointer">
+						<Link
+							href={href}
+							className={`flex items-center gap-3 w-full ${pathname === href ? 'text-primary font-medium' : ''}`}
+							onClick={() => setIsOpen(false)}
+						>
+							<Icon size={15} />
+							{label}
+						</Link>
+					</DropdownMenuItem>
+				))}
+				<DropdownMenuSeparator />
+				<DropdownMenuItem className="text-muted-foreground text-xs pointer-events-none">
+					Press ⌘K to search
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -8,62 +8,80 @@ import { currentUser } from '@/src/lib/utils';
 import NavLink from './nav-link';
 import MobileMenu from './mobile-menu';
 import { ThemeToggle } from './theme-toggle';
+import { TrendingUp } from 'lucide-react';
+import { CommandPaletteButton } from './command-palette-button';
 
 export default async function Navbar() {
 	const user = await currentUser();
 
 	return (
-		<nav className="flex items-center justify-between lg:mb-16 mb-8 px-4 py-3">
-			<div className="flex items-center">
-				<Link href="/" className="text-xl font-bold hover:text-primary transition-colors">
-					FinanceFlow
+		<header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur-md">
+			<nav className="container mx-auto flex items-center justify-between h-14 px-4">
+				{/* Logo */}
+				<Link href="/" className="flex items-center gap-2 font-bold text-base hover:opacity-80 transition-opacity shrink-0">
+					<div className="flex items-center justify-center w-7 h-7 rounded-md bg-primary">
+						<TrendingUp size={15} className="text-primary-foreground" />
+					</div>
+					<span>FinanceFlow</span>
 				</Link>
-			</div>
 
-			<div className="flex items-center">
-				<div className="lg:mx-4 hidden lg:block">
+				{/* Desktop nav links */}
+				<div className="hidden lg:flex items-center">
+					<NavLink href="/">Markets</NavLink>
+					<NavLink href="/dashboard">Dashboard</NavLink>
 					<NavLink href="/watchlist">Watchlist</NavLink>
 					<NavLink href="/blog">Blog</NavLink>
 				</div>
 
-				<DropdownMenu>
-					<DropdownMenuTrigger name="user_icon" aria-label="User button dropdown" className="focus:outline-none">
-						<Avatar className="items-center justify-center bg-muted hover:opacity-80 transition-opacity">
-							<AvatarImage src={user?.image ?? ''} alt={user?.name ?? ''} />
-							<AvatarFallback>
-								<FaUser className="h-5 w-5" />
-							</AvatarFallback>
-						</Avatar>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent className="w-48">
-						<DropdownMenuLabel>Account</DropdownMenuLabel>
-						<DropdownMenuSeparator />
-						<DropdownMenuItem className="cursor-pointer">
-							<Link href="/dashboard" className="w-full">
-								Dashboard
-							</Link>
-						</DropdownMenuItem>
-						{user?.role === UserRole.ADMIN && (
-							<DropdownMenuItem className="cursor-pointer">
-								<Link href="/admin" className="w-full">
-									Admin
-								</Link>
-							</DropdownMenuItem>
-						)}
-						{user && (
-							<>
-								<DropdownMenuSeparator />
-								<DropdownMenuItem className="cursor-pointer">
-									<SignOut />
-								</DropdownMenuItem>
-							</>
-						)}
-					</DropdownMenuContent>
-				</DropdownMenu>
+				{/* Right actions */}
+				<div className="flex items-center gap-1">
+					<CommandPaletteButton />
+					<ThemeToggle />
 
-				<ThemeToggle />
-				<MobileMenu />
-			</div>
-		</nav>
+					{/* User avatar dropdown */}
+					<DropdownMenu>
+						<DropdownMenuTrigger name="user_icon" aria-label="User menu" className="focus:outline-none ml-1">
+							<Avatar className="h-8 w-8 bg-muted hover:opacity-80 transition-opacity cursor-pointer">
+								<AvatarImage src={user?.image ?? ''} alt={user?.name ?? ''} />
+								<AvatarFallback>
+									<FaUser className="h-4 w-4" />
+								</AvatarFallback>
+							</Avatar>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="w-52">
+							{user?.name && (
+								<>
+									<DropdownMenuLabel className="font-normal pb-2">
+										<p className="font-semibold text-sm leading-none">{user.name}</p>
+										{user.email && (
+											<p className="text-xs text-muted-foreground mt-1 truncate">{user.email}</p>
+										)}
+									</DropdownMenuLabel>
+									<DropdownMenuSeparator />
+								</>
+							)}
+							<DropdownMenuItem asChild className="cursor-pointer">
+								<Link href="/dashboard" className="w-full">Dashboard</Link>
+							</DropdownMenuItem>
+							{user?.role === UserRole.ADMIN && (
+								<DropdownMenuItem asChild className="cursor-pointer">
+									<Link href="/admin" className="w-full">Admin</Link>
+								</DropdownMenuItem>
+							)}
+							{user && (
+								<>
+									<DropdownMenuSeparator />
+									<DropdownMenuItem className="cursor-pointer">
+										<SignOut />
+									</DropdownMenuItem>
+								</>
+							)}
+						</DropdownMenuContent>
+					</DropdownMenu>
+
+					<MobileMenu />
+				</div>
+			</nav>
+		</header>
 	);
 }


### PR DESCRIPTION
…n pages

Navbar:
- Sticky full-width with backdrop blur and border
- Logo with primary-colored icon (TrendingUp)
- Desktop nav: Markets, Dashboard, Watchlist, Blog
- Command palette trigger button with keyboard hint
- Avatar dropdown now shows user name + email

Mobile menu:
- All 4 links with icons (Markets, Dashboard, Watchlist, Blog)
- Active route highlighted

Footer:
- Themed border-t layout with brand, nav links, GitHub icon, copyright

Add to Portfolio (coin pages):
- New AddToPortfolioButton on every coin detail page
- Popover: select portfolio then confirm in one click
- Fetches user portfolios on demand via getMyPortfolios server action
- Shows create prompt if no portfolios exist

Layout: Navbar now renders outside container for true sticky full-width