### PR TITLE
feat: dashboard & portfolio UX overhaul — unified Add Transaction flow

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,22 +1,7 @@
-import FormProfil from '@/src/components/dashboard/formProfil';
 import Portfolio from '@/src/components/dashboard/portfolio/portfolio';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/src/components/ui/tabs';
+
+export const metadata = { title: 'Dashboard' };
 
 export default function Dashboard() {
-	return (
-		<div className="flex min-h-screen w-full flex-col">
-			<Tabs defaultValue="profil" className="">
-				<TabsList className="">
-					<TabsTrigger value="profil">Profil</TabsTrigger>
-					<TabsTrigger value="portfolio">Portfolio</TabsTrigger>
-				</TabsList>
-				<TabsContent value="profil">
-					<FormProfil />
-				</TabsContent>
-				<TabsContent value="portfolio">
-					<Portfolio />
-				</TabsContent>
-			</Tabs>
-		</div>
-	);
+	return <Portfolio />;
 }

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,0 +1,12 @@
+import FormProfil from '@/src/components/dashboard/formProfil';
+
+export const metadata = { title: 'Settings' };
+
+export default function SettingsPage() {
+	return (
+		<div className="max-w-2xl mx-auto py-6">
+			<h1 className="text-2xl font-bold mb-6">Account Settings</h1>
+			<FormProfil />
+		</div>
+	);
+}

--- a/src/actions/transaction/transaction.ts
+++ b/src/actions/transaction/transaction.ts
@@ -14,10 +14,11 @@ interface AddTransactionParams {
 	pricePerCoin: number;
 	fees?: number;
 	note?: string;
+	date?: Date;
 }
 
 export async function addTransaction(params: AddTransactionParams) {
-	const { portfolioId, coinId, quantityCrypto, amountUsd, type, pricePerCoin, fees, note } = params;
+	const { portfolioId, coinId, quantityCrypto, amountUsd, type, pricePerCoin, fees, note, date } = params;
 	if (!portfolioId || !coinId || !quantityCrypto || !amountUsd || !type || !pricePerCoin) {
 		throw new Error('Missing required transaction parameters');
 	}
@@ -41,7 +42,7 @@ export async function addTransaction(params: AddTransactionParams) {
 			pricePerCoin,
 			fees: fees || 0,
 			note,
-			date: new Date()
+			date: date ?? new Date()
 		}
 	});
 	revalidatePath(`/portfolios/${portfolioId}`);

--- a/src/components/coin-search.tsx
+++ b/src/components/coin-search.tsx
@@ -2,25 +2,30 @@ import React, { useState } from 'react';
 import { InstantSearch, SearchBox, Hits, Configure } from 'react-instantsearch';
 import { searchClient } from '@/src/lib/algolia/client';
 import Link from 'next/link';
-import { Plus } from 'lucide-react';
+import { Plus, Check } from 'lucide-react';
 import { Button } from './ui/button';
 import Image from 'next/image';
 import { useToast } from '@/src/hooks/use-toast';
 import { usePortfolioCoins } from './dashboard/portfolio/asset/portfolio-coin-provider';
 
-interface Hit {
+export interface CoinHit {
 	name: string;
 	symbol: string;
 	id: string;
 	image: string;
 }
 
-export default function CoinSearch({ portfolioId }: { readonly portfolioId: string }) {
+interface CoinSearchProps {
+	readonly portfolioId: string;
+	readonly onSelect?: (coin: CoinHit) => void;
+}
+
+export default function CoinSearch({ portfolioId, onSelect }: CoinSearchProps) {
 	const { addCoin, optimisticPortfolioCoins } = usePortfolioCoins();
 	const { toast } = useToast();
 	const [isAdding, setIsAdding] = useState<Record<string, boolean>>({});
 
-	const handleAddCoin = async (hit: Hit) => {
+	const handleAddCoin = async (hit: CoinHit) => {
 		const coinExists = optimisticPortfolioCoins.some((coin) => coin.coinId === hit.id);
 
 		if (coinExists) {
@@ -43,8 +48,30 @@ export default function CoinSearch({ portfolioId }: { readonly portfolioId: stri
 		}
 	};
 
-	const HitComponent = ({ hit }: { hit: Hit }) => {
+	const HitComponent = ({ hit }: { hit: CoinHit }) => {
 		const isInPortfolio = optimisticPortfolioCoins.some((coin) => coin.coinId === hit.id);
+
+		if (onSelect) {
+			return (
+				<div
+					className="p-3 hover:bg-muted/50 flex justify-between items-center cursor-pointer rounded-md transition-colors"
+					onClick={() => onSelect(hit)}
+				>
+					<div className="flex items-center gap-3">
+						<Image src={hit.image} alt={hit.name} width={28} height={28} className="rounded-full" />
+						<div>
+							<p className="font-medium text-sm">{hit.name}</p>
+							<p className="text-xs text-muted-foreground uppercase">{hit.symbol}</p>
+						</div>
+					</div>
+					{isInPortfolio && (
+						<span className="text-xs text-emerald-500 flex items-center gap-1">
+							<Check size={12} /> In portfolio
+						</span>
+					)}
+				</div>
+			);
+		}
 
 		return (
 			<div className="p-4 hover:bg-gray-50 flex justify-between items-center">

--- a/src/components/dashboard/portfolio/add-transaction-sheet.tsx
+++ b/src/components/dashboard/portfolio/add-transaction-sheet.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import * as z from 'zod';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/src/components/ui/sheet';
+import { Button } from '@/src/components/ui/button';
+import { Badge } from '@/src/components/ui/badge';
+import { Plus, ArrowLeft } from 'lucide-react';
+import { TransactionSchema } from '@/src/schemas/';
+import { TransactionForm } from './transaction/transaction-form';
+import CoinSearch, { CoinHit } from '@/src/components/coin-search';
+import { useTransactions } from './transaction/transaction-provider';
+import { useQuery } from '@tanstack/react-query';
+import { getCoinData } from '@/src/actions/external/crypto';
+import { Skeleton } from '@/src/components/ui/skeleton';
+import Image from 'next/image';
+
+interface AddTransactionSheetProps {
+	portfolioId: string;
+}
+
+export function AddTransactionSheet({ portfolioId }: AddTransactionSheetProps) {
+	const [open, setOpen] = useState(false);
+	const [step, setStep] = useState<1 | 2>(1);
+	const [selectedCoin, setSelectedCoin] = useState<CoinHit | null>(null);
+	const { addNewTransaction, isPending } = useTransactions();
+
+	const { data: coinData, isLoading: isLoadingCoin } = useQuery({
+		queryKey: ['coin', selectedCoin?.id],
+		queryFn: () => getCoinData(selectedCoin!.id),
+		enabled: !!selectedCoin?.id && step === 2,
+		staleTime: 5 * 60 * 1000
+	});
+
+	const handleCoinSelect = (coin: CoinHit) => {
+		setSelectedCoin(coin);
+		setStep(2);
+	};
+
+	const handleBack = () => {
+		setStep(1);
+		setSelectedCoin(null);
+	};
+
+	const handleSubmit = async (values: z.infer<typeof TransactionSchema>) => {
+		if (!selectedCoin) return;
+		await addNewTransaction(values, portfolioId, selectedCoin.id);
+		setOpen(false);
+		setStep(1);
+		setSelectedCoin(null);
+	};
+
+	const handleOpenChange = (isOpen: boolean) => {
+		setOpen(isOpen);
+		if (!isOpen) {
+			setStep(1);
+			setSelectedCoin(null);
+		}
+	};
+
+	return (
+		<Sheet open={open} onOpenChange={handleOpenChange}>
+			<SheetTrigger asChild>
+				<Button size="sm" className="gap-2">
+					<Plus size={15} />
+					Add Transaction
+				</Button>
+			</SheetTrigger>
+			<SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+				<SheetHeader className="mb-4">
+					<div className="flex items-center gap-2">
+						{step === 2 && (
+							<Button variant="ghost" size="icon" className="h-7 w-7" onClick={handleBack}>
+								<ArrowLeft size={16} />
+							</Button>
+						)}
+						<div>
+							<SheetTitle className="text-left">Add Transaction</SheetTitle>
+							<p className="text-xs text-muted-foreground mt-0.5">Step {step} of 2 — {step === 1 ? 'Select a coin' : 'Fill transaction details'}</p>
+						</div>
+					</div>
+				</SheetHeader>
+
+				{step === 1 && (
+					<div className="space-y-3">
+						<p className="text-sm text-muted-foreground">Search and select the cryptocurrency for this transaction.</p>
+						<CoinSearch portfolioId={portfolioId} onSelect={handleCoinSelect} />
+					</div>
+				)}
+
+				{step === 2 && selectedCoin && (
+					<div className="space-y-4">
+						{/* Selected coin preview */}
+						<div className="flex items-center gap-3 p-3 bg-muted/40 rounded-lg">
+							<Image src={selectedCoin.image} alt={selectedCoin.name} width={32} height={32} className="rounded-full" />
+							<div className="flex-1">
+								<p className="font-medium text-sm">{selectedCoin.name}</p>
+								<Badge variant="outline" className="text-xs uppercase mt-0.5">{selectedCoin.symbol}</Badge>
+							</div>
+						</div>
+
+						{isLoadingCoin ? (
+							<div className="space-y-3">
+								<Skeleton className="h-10 w-full" />
+								<div className="flex gap-4">
+									<Skeleton className="h-10 w-full" />
+									<Skeleton className="h-10 w-full" />
+								</div>
+								<Skeleton className="h-10 w-full" />
+								<Skeleton className="h-10 w-full" />
+							</div>
+						) : (
+							<TransactionForm
+								onSubmit={handleSubmit}
+								coin={coinData}
+								isPending={isPending}
+								error={null}
+								isEditMode={false}
+							/>
+						)}
+					</div>
+				)}
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/src/components/dashboard/portfolio/portfolio-overview.tsx
+++ b/src/components/dashboard/portfolio/portfolio-overview.tsx
@@ -5,7 +5,6 @@ import { PortfolioHistoryChart } from './statistic/portfolio-history-chart';
 import { PortfolioAllocationChart } from './statistic/portfolio-allocation-chart';
 import { AssetSummaryTable } from './asset/asset-summary-table';
 import { useTransactions } from './transaction/transaction-provider';
-import AssetDialog from './asset/asset-dialog';
 
 interface PortfolioOverviewProps {
 	portfolioId: string;
@@ -27,10 +26,7 @@ export function PortfolioOverview({ portfolioId }: PortfolioOverviewProps) {
 
 			{/* Asset table with coin-level drill-down */}
 			<div>
-				<div className="flex items-center justify-between mb-3">
-					<h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Holdings</h3>
-					<AssetDialog portfolioId={portfolioId} />
-				</div>
+				<h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">Holdings</h3>
 				<AssetSummaryTable portfolioId={portfolioId} />
 			</div>
 		</div>

--- a/src/components/dashboard/portfolio/transaction/transaction-provider.tsx
+++ b/src/components/dashboard/portfolio/transaction/transaction-provider.tsx
@@ -58,7 +58,8 @@ export function TransactionProvider({ children, portfolioId, coinId }: { childre
 				type: transaction.type,
 				pricePerCoin: transaction.pricePerCoin,
 				fees: transaction.fees ?? 0,
-				note: transaction.note ?? ''
+				note: transaction.note ?? '',
+				date: transaction.date
 			}),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['transactions', portfolioId] });

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -63,6 +63,9 @@ export default async function Navbar() {
 							<DropdownMenuItem asChild className="cursor-pointer">
 								<Link href="/dashboard" className="w-full">Dashboard</Link>
 							</DropdownMenuItem>
+							<DropdownMenuItem asChild className="cursor-pointer">
+								<Link href="/settings" className="w-full">Settings</Link>
+							</DropdownMenuItem>
 							{user?.role === UserRole.ADMIN && (
 								<DropdownMenuItem asChild className="cursor-pointer">
 									<Link href="/admin" className="w-full">Admin</Link>


### PR DESCRIPTION
- /dashboard now renders portfolio directly (no more Profil/Portfolio tabs)
- /settings new page for profile settings (FormProfil moved)
- AddTransactionSheet: 2-step flow (coin search → form) replaces separate Add Coin + Add Transaction dialogs
- CoinSearch: added onSelect prop for inline coin selection, exports CoinHit interface
- portfolio-list: removed Card wrapper, portfolio tabs (≤4) or Select, Add Transaction CTA always visible, auto-selects first portfolio
- portfolio-overview: removed AssetDialog from Holdings header
- navbar: Settings link added to user dropdown
- fix: addTransaction now correctly uses the date from the form (was always new Date())